### PR TITLE
Support handling multiple fields, not just search

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-prettier": "^3.3.1",
     "jest": "^26.6.3",
     "next": "^11.0.1",
-    "next-router-mock": "^0.1.4",
+    "next-router-mock": "^0.6.1",
     "prettier": "^2.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/readme.md
+++ b/readme.md
@@ -1,13 +1,13 @@
 React Pagination
 =============
 
-This package includes pagination hooks for React. The hooks support saving the search and pagination values in local
+This package includes pagination hooks for React. The hooks support saving the query and pagination values in local
 state or in the browser URL.
 
 ## Table of content
 
 - [Usage](#usage)
-    - [useSearchAndPagination](#usesearchandpagination)
+    - [useQueryAndPagination](#usequeryandpagination)
 - [Supported Implementations](#supported-implementations)
     - [In Memory Pagination](#in-memory-pagination)
     - [React-Router based pagination](#react-router-based-pagination)
@@ -23,7 +23,7 @@ First, you have to install the package:
 npm install @aboutbits/react-pagination
 ```
 
-Second, you can make use of the `useSearchAndPagination` hook. This package implements 3 versions of this hook:
+Second, you can make use of the `useQueryAndPagination` hook. This package implements 3 versions of this hook:
 
 - [In Memory](#in-memory-pagination): Use this hook where you don't want to modify browser history. e.g. Dialogs
 - [React Router](#react-router-based-pagination): Use this hook if you want to keep track of the state in the URL and
@@ -31,9 +31,9 @@ Second, you can make use of the `useSearchAndPagination` hook. This package impl
 - [NextJS Router](#nextjs-router-based-pagination): Use this hook if you want to keep track of the state in the URL and
   your project is using NextJS.
 
-### useSearchAndPagination
+### useQueryAndPagination
 
-This hook supports the combination of a search value and pagination and manages the state of the search value, and the
+This hook supports the combination of query parameters and pagination and manages the state of the query parameter values and the
 pagination values.
 
 #### The hook supports following configuration parameter object:
@@ -42,31 +42,32 @@ pagination values.
 |---|---|---|---|
 |indexType|IndexType|IndexType.ZERO_BASED|It defines whether the pagination is zero or one based.|
 |pageSize|number|15|Page size of the pagination.|
+|defaultQueryParameters/Record<string, string>|{}|It defines the default value for each query parameter. This is used to remove a query parameter from the URL and also to clear the query.
 
 #### The hook returns the following object:
 
 |value|type|description|
 |---|---|---|
-|search|string|value of your search parameter|
+|queryParameters|object|values of your query parameters|
 |page|number|value of the current page|
 |size|number|max elements in a single page|
-|actions|object|object with 3 functions: search, setPage, clear|
+|actions|object|object with 3 functions: updateQuery, setPage, clear|
 
 #### Example usage with NextJS
 
 ```tsx
-import { useSearchAndPagination } from '@aboutbits/react-pagination/dist/nextRouterPagination'
+import { useQueryAndPagination } from '@aboutbits/react-pagination/dist/nextRouterPagination'
 
 const users = [
     'Alex', 'Simon', 'Natan', 'Nadia', 'Moritz', 'Marie'
 ]
 
 function UserList() {
-    const { page, size, search, actions } = useSearchAndPagination({pageSize: 2})
+    const { page, size, queryParameters, actions } = useQueryAndPagination({pageSize: 2})
 
     return (
         <div>
-            <input onChange={(value) => actions.search(value)}/>
+            <input onChange={(value) => actions.updateQuery({search: value})}/>
             <button onClick={() => actions.clear()}>Clear Input</button>
             <select onSelect={(value) => actions.setPage(value)}>
                 <option value={0}>First Page</option>
@@ -74,7 +75,7 @@ function UserList() {
             </select>
 
             <ul>
-                {users.filter(user => user.startsWith(search))
+                {users.filter(user => user.startsWith(queryParameters.search))
                     .slice(page, page + size)
                     .map(user => <li>{user}</li>)}
             </ul>
@@ -96,7 +97,7 @@ This package includes 3 different implementations of the above hook.
 Use this pagination hook if you want to keep track of the pagination in memory. This is very handy for dialogs.
 
 ```tsx
-import { useSearchAndPagination } from '@aboutbits/react-pagination/dist/inMemoryPagination'
+import { useQueryAndPagination } from '@aboutbits/react-pagination/dist/inMemoryPagination'
 ```
 
 ### React-Router based pagination
@@ -104,7 +105,7 @@ import { useSearchAndPagination } from '@aboutbits/react-pagination/dist/inMemor
 These are specific hooks for applications that use [React Router](https://reactrouter.com/) for routing.
 
 ```tsx
-import { useSearchAndPagination } from '@aboutbits/react-pagination/dist/reactRouterPagination'
+import { useQueryAndPagination } from '@aboutbits/react-pagination/dist/reactRouterPagination'
 ```
 
 ### NextJS Router based pagination
@@ -113,7 +114,7 @@ These are specific hooks for applications that use [NextJS Router](https://nextj
 for routing.
 
 ```tsx
-import { useSearchAndPagination } from '@aboutbits/react-pagination/dist/nextRouterPagination'
+import { useQueryAndPagination } from '@aboutbits/react-pagination/dist/nextRouterPagination'
 ```
 
 ## Build & Publish

--- a/src/__test__/inMemoryPagination.test.ts
+++ b/src/__test__/inMemoryPagination.test.ts
@@ -82,3 +82,36 @@ test('change default parameters', () => {
   expect(result.current.page).toBe(1)
   expect(result.current.size).toBe(10)
 })
+
+test('query multiple different properties, should keep them all', () => {
+  const { result } = renderHook(() =>
+    useQueryAndPagination({
+      defaultQueryParameters: { query: '', department: '' },
+    })
+  )
+
+  act(() => {
+    result.current.actions.query({ query: 'Max' })
+    result.current.actions.query({ department: 'IT' })
+  })
+
+  expect(result.current.queryParameters.query).toBe('Max')
+  expect(result.current.queryParameters.department).toBe('IT')
+})
+
+test('query a property that is not configured, should do nothing', () => {
+  const { result } = renderHook(() =>
+    useQueryAndPagination({
+      defaultQueryParameters: { query: '' },
+    })
+  )
+
+  act(() => {
+    result.current.actions.query({ department: 'IT' })
+  })
+
+  expect(result.current.queryParameters.query).toBe('')
+  expect(result.current.queryParameters.department).toBeUndefined()
+})
+
+// test('properties in the URL, that are not part of the configuration should be left untouched', () => {})

--- a/src/__test__/inMemoryPagination.test.ts
+++ b/src/__test__/inMemoryPagination.test.ts
@@ -25,7 +25,7 @@ test('should change search', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -43,7 +43,7 @@ test('on search change -> page should be reset', () => {
   expect(result.current.page).toBe(2)
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -56,7 +56,7 @@ test('clear pagination should reset search and page', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   act(() => {
@@ -91,8 +91,8 @@ test('query multiple different properties, should keep them all', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
-    result.current.actions.query({ department: 'IT' })
+    result.current.actions.updateQuery({ search: 'Max' })
+    result.current.actions.updateQuery({ department: 'IT' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -107,7 +107,7 @@ test('query a property that is not configured, should do nothing', () => {
   )
 
   act(() => {
-    result.current.actions.query({ department: 'IT' })
+    result.current.actions.updateQuery({ department: 'IT' })
   })
 
   expect(result.current.queryParameters.search).toBe('')

--- a/src/__test__/inMemoryPagination.test.ts
+++ b/src/__test__/inMemoryPagination.test.ts
@@ -21,19 +21,19 @@ test('should change page', () => {
 
 test('should change search', () => {
   const { result } = renderHook(() =>
-    useQueryAndPagination({ defaultQueryParameters: { query: '' } })
+    useQueryAndPagination({ defaultQueryParameters: { search: '' } })
   )
 
   act(() => {
-    result.current.actions.query({ query: 'Max' })
+    result.current.actions.query({ search: 'Max' })
   })
 
-  expect(result.current.queryParameters.query).toBe('Max')
+  expect(result.current.queryParameters.search).toBe('Max')
 })
 
 test('on search change -> page should be reset', () => {
   const { result } = renderHook(() =>
-    useQueryAndPagination({ defaultQueryParameters: { query: '' } })
+    useQueryAndPagination({ defaultQueryParameters: { search: '' } })
   )
 
   act(() => {
@@ -43,34 +43,34 @@ test('on search change -> page should be reset', () => {
   expect(result.current.page).toBe(2)
 
   act(() => {
-    result.current.actions.query({ query: 'Max' })
+    result.current.actions.query({ search: 'Max' })
   })
 
-  expect(result.current.queryParameters.query).toBe('Max')
+  expect(result.current.queryParameters.search).toBe('Max')
   expect(result.current.page).toBe(0)
 })
 
 test('clear pagination should reset search and page', () => {
   const { result } = renderHook(() =>
-    useQueryAndPagination({ defaultQueryParameters: { query: '' } })
+    useQueryAndPagination({ defaultQueryParameters: { search: '' } })
   )
 
   act(() => {
-    result.current.actions.query({ query: 'Max' })
+    result.current.actions.query({ search: 'Max' })
   })
 
   act(() => {
     result.current.actions.setPage(2)
   })
 
-  expect(result.current.queryParameters.query).toBe('Max')
+  expect(result.current.queryParameters.search).toBe('Max')
   expect(result.current.page).toBe(2)
 
   act(() => {
     result.current.actions.clear()
   })
 
-  expect(result.current.queryParameters.query).toBe('')
+  expect(result.current.queryParameters.search).toBe('')
   expect(result.current.page).toBe(0)
 })
 
@@ -86,23 +86,23 @@ test('change default parameters', () => {
 test('query multiple different properties, should keep them all', () => {
   const { result } = renderHook(() =>
     useQueryAndPagination({
-      defaultQueryParameters: { query: '', department: '' },
+      defaultQueryParameters: { search: '', department: '' },
     })
   )
 
   act(() => {
-    result.current.actions.query({ query: 'Max' })
+    result.current.actions.query({ search: 'Max' })
     result.current.actions.query({ department: 'IT' })
   })
 
-  expect(result.current.queryParameters.query).toBe('Max')
+  expect(result.current.queryParameters.search).toBe('Max')
   expect(result.current.queryParameters.department).toBe('IT')
 })
 
 test('query a property that is not configured, should do nothing', () => {
   const { result } = renderHook(() =>
     useQueryAndPagination({
-      defaultQueryParameters: { query: '' },
+      defaultQueryParameters: { search: '' },
     })
   )
 
@@ -110,8 +110,6 @@ test('query a property that is not configured, should do nothing', () => {
     result.current.actions.query({ department: 'IT' })
   })
 
-  expect(result.current.queryParameters.query).toBe('')
+  expect(result.current.queryParameters.search).toBe('')
   expect(result.current.queryParameters.department).toBeUndefined()
 })
-
-// test('properties in the URL, that are not part of the configuration should be left untouched', () => {})

--- a/src/__test__/inMemoryPagination.test.ts
+++ b/src/__test__/inMemoryPagination.test.ts
@@ -1,17 +1,16 @@
 import { act, renderHook } from '@testing-library/react-hooks'
-import { useSearchAndPagination } from '../inMemoryPagination'
+import { useQueryAndPagination } from '../inMemoryPagination'
 import { IndexType } from '../types'
 
 test('should initialize pagination', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
+  const { result } = renderHook(() => useQueryAndPagination())
 
   expect(result.current.page).toBe(0)
-  expect(result.current.search).toBe('')
   expect(result.current.size).toBe(15)
 })
 
 test('should change page', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
+  const { result } = renderHook(() => useQueryAndPagination())
 
   act(() => {
     result.current.actions.setPage(2)
@@ -21,17 +20,21 @@ test('should change page', () => {
 })
 
 test('should change search', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
+  const { result } = renderHook(() =>
+    useQueryAndPagination({ defaultQueryParameters: { query: '' } })
+  )
 
   act(() => {
-    result.current.actions.search('Max')
+    result.current.actions.query({ query: 'Max' })
   })
 
-  expect(result.current.search).toBe('Max')
+  expect(result.current.queryParameters.query).toBe('Max')
 })
 
 test('on search change -> page should be reset', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
+  const { result } = renderHook(() =>
+    useQueryAndPagination({ defaultQueryParameters: { query: '' } })
+  )
 
   act(() => {
     result.current.actions.setPage(2)
@@ -40,38 +43,40 @@ test('on search change -> page should be reset', () => {
   expect(result.current.page).toBe(2)
 
   act(() => {
-    result.current.actions.search('Max')
+    result.current.actions.query({ query: 'Max' })
   })
 
-  expect(result.current.search).toBe('Max')
+  expect(result.current.queryParameters.query).toBe('Max')
   expect(result.current.page).toBe(0)
 })
 
 test('clear pagination should reset search and page', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
+  const { result } = renderHook(() =>
+    useQueryAndPagination({ defaultQueryParameters: { query: '' } })
+  )
 
   act(() => {
-    result.current.actions.search('Max')
+    result.current.actions.query({ query: 'Max' })
   })
 
   act(() => {
     result.current.actions.setPage(2)
   })
 
-  expect(result.current.search).toBe('Max')
+  expect(result.current.queryParameters.query).toBe('Max')
   expect(result.current.page).toBe(2)
 
   act(() => {
     result.current.actions.clear()
   })
 
-  expect(result.current.search).toBe('')
+  expect(result.current.queryParameters.query).toBe('')
   expect(result.current.page).toBe(0)
 })
 
 test('change default parameters', () => {
   const { result } = renderHook(() =>
-    useSearchAndPagination({ indexType: IndexType.ONE_BASED, pageSize: 10 })
+    useQueryAndPagination({ indexType: IndexType.ONE_BASED, pageSize: 10 })
   )
 
   expect(result.current.page).toBe(1)

--- a/src/__test__/nextRouterPagination.test.tsx
+++ b/src/__test__/nextRouterPagination.test.tsx
@@ -109,6 +109,9 @@ test('query multiple different properties, should keep them all', () => {
 
   act(() => {
     result.current.actions.updateQuery({ search: 'Max' })
+  })
+
+  act(() => {
     result.current.actions.updateQuery({ department: 'IT' })
   })
 

--- a/src/__test__/nextRouterPagination.test.tsx
+++ b/src/__test__/nextRouterPagination.test.tsx
@@ -99,3 +99,69 @@ test('on search change -> page should be reset', () => {
   expect(router.query.search).toBe('Max')
   expect(router.query.page).toBeUndefined()
 })
+
+test('query multiple different properties, should keep them all', () => {
+  const { result } = renderHook(() =>
+    useQueryAndPagination({
+      defaultQueryParameters: { search: '', department: '' },
+    })
+  )
+
+  act(() => {
+    result.current.actions.query({ search: 'Max' })
+    result.current.actions.query({ department: 'IT' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('Max')
+  expect(result.current.queryParameters.department).toBe('IT')
+})
+
+test('query a property that is not configured, should do nothing', () => {
+  const { result } = renderHook(() =>
+    useQueryAndPagination({
+      defaultQueryParameters: { search: '' },
+    })
+  )
+
+  act(() => {
+    result.current.actions.query({ department: 'IT' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('')
+  expect(result.current.queryParameters.department).toBeUndefined()
+})
+
+test('properties in the URL, that are not part of the configuration should be left untouched', () => {
+  router.query = { greeting: 'hello' }
+
+  const { result } = renderHook(() =>
+    useQueryAndPagination({
+      defaultQueryParameters: { search: '' },
+    })
+  )
+
+  act(() => {
+    result.current.actions.query({ search: 'Max' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('Max')
+  expect(result.current.queryParameters.greeting).toBeUndefined()
+  expect(router.query.greeting).toBe('hello')
+})
+
+test('query property with default value, should remove it from url', () => {
+  router.query = { search: 'Max' }
+
+  const { result } = renderHook(() =>
+    useQueryAndPagination({
+      defaultQueryParameters: { search: '' },
+    })
+  )
+
+  act(() => {
+    result.current.actions.query({ search: '' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('')
+  expect(router.query.search).toBeUndefined()
+})

--- a/src/__test__/nextRouterPagination.test.tsx
+++ b/src/__test__/nextRouterPagination.test.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { act, renderHook } from '@testing-library/react-hooks'
 import router from 'next/router'
 
-import { useSearchAndPagination } from '../nextRouterPagination'
+import { useQueryAndPagination } from '../nextRouterPagination'
 import { IndexType } from '../types'
 
 jest.mock('next/router', () => require('next-router-mock'))
@@ -13,14 +13,14 @@ beforeEach(() => {
 })
 
 test('should initialize pagination', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
+  const { result } = renderHook(() => useQueryAndPagination())
 
   expect(result.current.page).toBe(0)
   expect(result.current.size).toBe(15)
 })
 
 test('should change page', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
+  const { result } = renderHook(() => useQueryAndPagination())
 
   act(() => {
     result.current.actions.setPage(2)
@@ -32,7 +32,7 @@ test('should change page', () => {
 
 test('should change search', () => {
   const { result } = renderHook(() =>
-    useSearchAndPagination({ defaultQueryParameters: { search: '' } })
+    useQueryAndPagination({ defaultQueryParameters: { search: '' } })
   )
 
   act(() => {
@@ -45,7 +45,7 @@ test('should change search', () => {
 
 test('clear pagination should reset search and page', () => {
   const { result } = renderHook(() =>
-    useSearchAndPagination({ defaultQueryParameters: { search: '' } })
+    useQueryAndPagination({ defaultQueryParameters: { search: '' } })
   )
 
   act(() => {
@@ -71,7 +71,7 @@ test('clear pagination should reset search and page', () => {
 
 test('change default parameters', () => {
   const { result } = renderHook(() =>
-    useSearchAndPagination({ indexType: IndexType.ONE_BASED, pageSize: 10 })
+    useQueryAndPagination({ indexType: IndexType.ONE_BASED, pageSize: 10 })
   )
 
   expect(result.current.page).toBe(1)
@@ -80,7 +80,7 @@ test('change default parameters', () => {
 
 test('on search change -> page should be reset', () => {
   const { result } = renderHook(() =>
-    useSearchAndPagination({ defaultQueryParameters: { search: '' } })
+    useQueryAndPagination({ defaultQueryParameters: { search: '' } })
   )
 
   act(() => {

--- a/src/__test__/nextRouterPagination.test.tsx
+++ b/src/__test__/nextRouterPagination.test.tsx
@@ -36,7 +36,7 @@ test('should change search', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -49,7 +49,7 @@ test('clear pagination should reset search and page', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   act(() => {
@@ -91,7 +91,7 @@ test('on search change -> page should be reset', () => {
   expect(router.query.page).toBe('2')
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -108,8 +108,8 @@ test('query multiple different properties, should keep them all', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
-    result.current.actions.query({ department: 'IT' })
+    result.current.actions.updateQuery({ search: 'Max' })
+    result.current.actions.updateQuery({ department: 'IT' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -124,7 +124,7 @@ test('query a property that is not configured, should do nothing', () => {
   )
 
   act(() => {
-    result.current.actions.query({ department: 'IT' })
+    result.current.actions.updateQuery({ department: 'IT' })
   })
 
   expect(result.current.queryParameters.search).toBe('')
@@ -141,7 +141,7 @@ test('properties in the URL, that are not part of the configuration should be le
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -159,7 +159,7 @@ test('query property with default value, should remove it from url', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: '' })
+    result.current.actions.updateQuery({ search: '' })
   })
 
   expect(result.current.queryParameters.search).toBe('')

--- a/src/__test__/nextRouterPagination.test.tsx
+++ b/src/__test__/nextRouterPagination.test.tsx
@@ -8,11 +8,14 @@ import { IndexType } from '../types'
 
 jest.mock('next/router', () => require('next-router-mock'))
 
+beforeEach(() => {
+  router.query = {}
+})
+
 test('should initialize pagination', () => {
   const { result } = renderHook(() => useSearchAndPagination())
 
   expect(result.current.page).toBe(0)
-  expect(result.current.search).toBe('')
   expect(result.current.size).toBe(15)
 })
 
@@ -28,41 +31,25 @@ test('should change page', () => {
 })
 
 test('should change search', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
+  const { result } = renderHook(() =>
+    useSearchAndPagination({ defaultQueryParameters: { search: '' } })
+  )
 
   act(() => {
-    result.current.actions.search('Max')
+    result.current.actions.query({ search: 'Max' })
   })
 
-  expect(result.current.search).toBe('Max')
+  expect(result.current.queryParameters.search).toBe('Max')
   expect(router.query.search).toBe('Max')
-})
-
-test('on search change -> page should be reset', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
-
-  act(() => {
-    result.current.actions.setPage(2)
-  })
-
-  expect(result.current.page).toBe(2)
-  expect(router.query.page).toBe('2')
-
-  act(() => {
-    result.current.actions.search('Max')
-  })
-
-  expect(result.current.search).toBe('Max')
-  expect(result.current.page).toBe(0)
-  expect(router.query.search).toBe('Max')
-  expect(router.query.page).toBeUndefined()
 })
 
 test('clear pagination should reset search and page', () => {
-  const { result } = renderHook(() => useSearchAndPagination())
+  const { result } = renderHook(() =>
+    useSearchAndPagination({ defaultQueryParameters: { search: '' } })
+  )
 
   act(() => {
-    result.current.actions.search('Max')
+    result.current.actions.query({ search: 'Max' })
   })
 
   act(() => {
@@ -76,7 +63,7 @@ test('clear pagination should reset search and page', () => {
     result.current.actions.clear()
   })
 
-  expect(result.current.search).toBe('')
+  expect(result.current.queryParameters.search).toBe('')
   expect(result.current.page).toBe(0)
   expect(router.query.search).toBeUndefined()
   expect(router.query.page).toBeUndefined()
@@ -89,4 +76,26 @@ test('change default parameters', () => {
 
   expect(result.current.page).toBe(1)
   expect(result.current.size).toBe(10)
+})
+
+test('on search change -> page should be reset', () => {
+  const { result } = renderHook(() =>
+    useSearchAndPagination({ defaultQueryParameters: { search: '' } })
+  )
+
+  act(() => {
+    result.current.actions.setPage(2)
+  })
+
+  expect(result.current.page).toBe(2)
+  expect(router.query.page).toBe('2')
+
+  act(() => {
+    result.current.actions.query({ search: 'Max' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('Max')
+  expect(result.current.page).toBe(0)
+  expect(router.query.search).toBe('Max')
+  expect(router.query.page).toBeUndefined()
 })

--- a/src/__test__/reactRouterPagination.test.tsx
+++ b/src/__test__/reactRouterPagination.test.tsx
@@ -34,7 +34,7 @@ test('should change search', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -48,7 +48,7 @@ test('clear pagination should reset search and page', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   act(() => {
@@ -88,8 +88,8 @@ test('query multiple different properties, should keep them all', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
-    result.current.actions.query({ department: 'IT' })
+    result.current.actions.updateQuery({ search: 'Max' })
+    result.current.actions.updateQuery({ department: 'IT' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -106,7 +106,7 @@ test('query a property that is not configured, should do nothing', () => {
   )
 
   act(() => {
-    result.current.actions.query({ department: 'IT' })
+    result.current.actions.updateQuery({ department: 'IT' })
   })
 
   expect(result.current.queryParameters.search).toBe('')
@@ -125,7 +125,7 @@ test('properties in the URL, that are not part of the configuration should be le
   )
 
   act(() => {
-    result.current.actions.query({ search: 'Max' })
+    result.current.actions.updateQuery({ search: 'Max' })
   })
 
   expect(result.current.queryParameters.search).toBe('Max')
@@ -145,7 +145,7 @@ test('query property with default value, should remove it from url', () => {
   )
 
   act(() => {
-    result.current.actions.query({ search: '' })
+    result.current.actions.updateQuery({ search: '' })
   })
 
   expect(result.current.queryParameters.search).toBe('')

--- a/src/__test__/reactRouterPagination.test.tsx
+++ b/src/__test__/reactRouterPagination.test.tsx
@@ -47,8 +47,6 @@ test('clear pagination should reset search and page', () => {
     { wrapper }
   )
 
-  console.log(window.location.search)
-
   act(() => {
     result.current.actions.query({ search: 'Max' })
   })
@@ -78,4 +76,78 @@ test('change default parameters', () => {
 
   expect(result.current.page).toBe(1)
   expect(result.current.size).toBe(10)
+})
+
+test('query multiple different properties, should keep them all', () => {
+  const { result } = renderHook(
+    () =>
+      useQueryAndPagination({
+        defaultQueryParameters: { search: '', department: '' },
+      }),
+    { wrapper }
+  )
+
+  act(() => {
+    result.current.actions.query({ search: 'Max' })
+    result.current.actions.query({ department: 'IT' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('Max')
+  expect(result.current.queryParameters.department).toBe('IT')
+})
+
+test('query a property that is not configured, should do nothing', () => {
+  const { result } = renderHook(
+    () =>
+      useQueryAndPagination({
+        defaultQueryParameters: { search: '' },
+      }),
+    { wrapper }
+  )
+
+  act(() => {
+    result.current.actions.query({ department: 'IT' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('')
+  expect(result.current.queryParameters.department).toBeUndefined()
+})
+
+test('properties in the URL, that are not part of the configuration should be left untouched', () => {
+  window.history.pushState({}, '', '/?greeting=hello')
+
+  const { result } = renderHook(
+    () =>
+      useQueryAndPagination({
+        defaultQueryParameters: { search: '' },
+      }),
+    { wrapper }
+  )
+
+  act(() => {
+    result.current.actions.query({ search: 'Max' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('Max')
+  expect(result.current.queryParameters.greeting).toBeUndefined()
+  expect(window.location.search).toBe('?greeting=hello&search=Max')
+})
+
+test('query property with default value, should remove it from url', () => {
+  window.history.pushState({}, '', '/?search=Anton')
+
+  const { result } = renderHook(
+    () =>
+      useQueryAndPagination({
+        defaultQueryParameters: { search: '' },
+      }),
+    { wrapper }
+  )
+
+  act(() => {
+    result.current.actions.query({ search: '' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('')
+  expect(window.location.search).toBe('')
 })

--- a/src/__test__/reactRouterPagination.test.tsx
+++ b/src/__test__/reactRouterPagination.test.tsx
@@ -1,21 +1,23 @@
 import React from 'react'
 import { act, renderHook } from '@testing-library/react-hooks'
 import { BrowserRouter as Router } from 'react-router-dom'
-import { useSearchAndPagination } from '../reactRouterPagination'
+import { useQueryAndPagination } from '../reactRouterPagination'
 import { IndexType } from '../types'
-
 const wrapper: React.FC = ({ children }) => <Router>{children}</Router>
 
+beforeEach(() => {
+  window.history.pushState({}, '', '/')
+})
+
 test('should initialize pagination', () => {
-  const { result } = renderHook(() => useSearchAndPagination(), { wrapper })
+  const { result } = renderHook(() => useQueryAndPagination(), { wrapper })
 
   expect(result.current.page).toBe(0)
-  expect(result.current.query).toBe('')
   expect(result.current.size).toBe(15)
 })
 
 test('should change page', () => {
-  const { result } = renderHook(() => useSearchAndPagination(), { wrapper })
+  const { result } = renderHook(() => useQueryAndPagination(), { wrapper })
 
   act(() => {
     result.current.actions.setPage(2)
@@ -26,53 +28,43 @@ test('should change page', () => {
 })
 
 test('should change search', () => {
-  const { result } = renderHook(() => useSearchAndPagination(), { wrapper })
+  const { result } = renderHook(
+    () => useQueryAndPagination({ defaultQueryParameters: { search: '' } }),
+    { wrapper }
+  )
 
   act(() => {
-    result.current.actions.query('Max')
+    result.current.actions.query({ search: 'Max' })
   })
 
-  expect(result.current.query).toBe('Max')
-  expect(window.location.search).toBe('?search=Max')
-})
-
-test('on search change -> page should be reset', () => {
-  const { result } = renderHook(() => useSearchAndPagination(), { wrapper })
-
-  act(() => {
-    result.current.actions.setPage(2)
-  })
-
-  expect(result.current.page).toBe(2)
-
-  act(() => {
-    result.current.actions.query('Max')
-  })
-
-  expect(result.current.query).toBe('Max')
-  expect(result.current.page).toBe(0)
+  expect(result.current.queryParameters.search).toBe('Max')
   expect(window.location.search).toBe('?search=Max')
 })
 
 test('clear pagination should reset search and page', () => {
-  const { result } = renderHook(() => useSearchAndPagination(), { wrapper })
+  const { result } = renderHook(
+    () => useQueryAndPagination({ defaultQueryParameters: { search: '' } }),
+    { wrapper }
+  )
+
+  console.log(window.location.search)
 
   act(() => {
-    result.current.actions.query('Max')
+    result.current.actions.query({ search: 'Max' })
   })
 
   act(() => {
     result.current.actions.setPage(2)
   })
 
-  expect(result.current.query).toBe('Max')
+  expect(result.current.queryParameters.search).toBe('Max')
   expect(result.current.page).toBe(2)
 
   act(() => {
     result.current.actions.clear()
   })
 
-  expect(result.current.query).toBe('')
+  expect(result.current.queryParameters.search).toBe('')
   expect(result.current.page).toBe(0)
   expect(window.location.search).toBe('')
 })
@@ -80,7 +72,7 @@ test('clear pagination should reset search and page', () => {
 test('change default parameters', () => {
   const { result } = renderHook(
     () =>
-      useSearchAndPagination({ indexType: IndexType.ONE_BASED, pageSize: 10 }),
+      useQueryAndPagination({ indexType: IndexType.ONE_BASED, pageSize: 10 }),
     { wrapper }
   )
 

--- a/src/__test__/reactRouterPagination.testostpesto.tsx
+++ b/src/__test__/reactRouterPagination.testostpesto.tsx
@@ -10,7 +10,7 @@ test('should initialize pagination', () => {
   const { result } = renderHook(() => useSearchAndPagination(), { wrapper })
 
   expect(result.current.page).toBe(0)
-  expect(result.current.search).toBe('')
+  expect(result.current.query).toBe('')
   expect(result.current.size).toBe(15)
 })
 
@@ -29,10 +29,10 @@ test('should change search', () => {
   const { result } = renderHook(() => useSearchAndPagination(), { wrapper })
 
   act(() => {
-    result.current.actions.search('Max')
+    result.current.actions.query('Max')
   })
 
-  expect(result.current.search).toBe('Max')
+  expect(result.current.query).toBe('Max')
   expect(window.location.search).toBe('?search=Max')
 })
 
@@ -46,10 +46,10 @@ test('on search change -> page should be reset', () => {
   expect(result.current.page).toBe(2)
 
   act(() => {
-    result.current.actions.search('Max')
+    result.current.actions.query('Max')
   })
 
-  expect(result.current.search).toBe('Max')
+  expect(result.current.query).toBe('Max')
   expect(result.current.page).toBe(0)
   expect(window.location.search).toBe('?search=Max')
 })
@@ -58,21 +58,21 @@ test('clear pagination should reset search and page', () => {
   const { result } = renderHook(() => useSearchAndPagination(), { wrapper })
 
   act(() => {
-    result.current.actions.search('Max')
+    result.current.actions.query('Max')
   })
 
   act(() => {
     result.current.actions.setPage(2)
   })
 
-  expect(result.current.search).toBe('Max')
+  expect(result.current.query).toBe('Max')
   expect(result.current.page).toBe(2)
 
   act(() => {
     result.current.actions.clear()
   })
 
-  expect(result.current.search).toBe('')
+  expect(result.current.query).toBe('')
   expect(result.current.page).toBe(0)
   expect(window.location.search).toBe('')
 })

--- a/src/inMemoryPagination.tsx
+++ b/src/inMemoryPagination.tsx
@@ -17,13 +17,26 @@ export const useQueryAndPagination: IUseQueryAndPagination = function (config) {
 
   const query = useCallback((queryParameters: QueryParameters) => {
     setState((currentState) => {
+      const updatedQueryParameters = {
+        ...currentState.queryParameters,
+        ...queryParameters,
+      }
+
+      for (const parameter in queryParameters) {
+        if (
+          !!config?.defaultQueryParameters &&
+          (config.defaultQueryParameters[parameter] === undefined ||
+            config.defaultQueryParameters[parameter] ===
+              queryParameters[parameter])
+        ) {
+          delete updatedQueryParameters[parameter]
+        }
+      }
+
       return {
         ...currentState,
         page: 0,
-        queryParameters: {
-          ...currentState.queryParameters,
-          ...queryParameters,
-        },
+        queryParameters: updatedQueryParameters,
       }
     })
   }, [])

--- a/src/inMemoryPagination.tsx
+++ b/src/inMemoryPagination.tsx
@@ -1,28 +1,29 @@
 import { useCallback, useMemo, useState } from 'react'
-import { IndexType, IUseSearchAndPagination } from './types'
+import { IndexType, IUseQueryAndPagination, QueryParameters } from './types'
 
-export const useSearchAndPagination: IUseSearchAndPagination = function (
-  config
-) {
+export const useQueryAndPagination: IUseQueryAndPagination = function (config) {
   const { indexType = IndexType.ZERO_BASED, pageSize = 15 } = config || {}
   const firstPage = indexType === IndexType.ZERO_BASED ? 0 : 1
   const initialState = useMemo(
     () => ({
       page: firstPage,
       size: pageSize,
-      searchQuery: '',
+      queryParameters: config?.defaultQueryParameters || {},
     }),
     []
   )
 
   const [state, setState] = useState(initialState)
 
-  const search = useCallback((query: string) => {
+  const query = useCallback((queryParameters: QueryParameters) => {
     setState((currentState) => {
       return {
         ...currentState,
         page: 0,
-        searchQuery: query,
+        queryParameters: {
+          ...currentState.queryParameters,
+          ...queryParameters,
+        },
       }
     })
   }, [])
@@ -43,9 +44,9 @@ export const useSearchAndPagination: IUseSearchAndPagination = function (
   }, [])
 
   return {
-    search: state.searchQuery,
+    queryParameters: state.queryParameters,
     actions: {
-      search,
+      query,
       clear,
       setPage,
     },

--- a/src/inMemoryPagination.tsx
+++ b/src/inMemoryPagination.tsx
@@ -15,7 +15,7 @@ export const useQueryAndPagination: IUseQueryAndPagination = function (config) {
 
   const [state, setState] = useState(initialState)
 
-  const query = useCallback((queryParameters: QueryParameters) => {
+  const updateQuery = useCallback((queryParameters: QueryParameters) => {
     setState((currentState) => {
       const updatedQueryParameters = {
         ...currentState.queryParameters,
@@ -59,7 +59,7 @@ export const useQueryAndPagination: IUseQueryAndPagination = function (config) {
   return {
     queryParameters: state.queryParameters,
     actions: {
-      query,
+      updateQuery,
       clear,
       setPage,
     },

--- a/src/nextRouterPagination.tsx
+++ b/src/nextRouterPagination.tsx
@@ -51,7 +51,7 @@ export const useQueryAndPagination: IUseQueryAndPagination = function (config) {
     [router]
   )
 
-  const query = useCallback(
+  const updateQuery = useCallback(
     (queryParameters: QueryParameters) => {
       const params = {
         ...router.query,
@@ -107,7 +107,7 @@ export const useQueryAndPagination: IUseQueryAndPagination = function (config) {
     ),
     size: convert(getSingleParameterValue(router.query.size) || null, pageSize),
     actions: {
-      query,
+      updateQuery,
       clear,
       setPage,
     },

--- a/src/nextRouterPagination.tsx
+++ b/src/nextRouterPagination.tsx
@@ -33,9 +33,7 @@ function extractCurrentQueryParameters(
   return result
 }
 
-export const useSearchAndPagination: IUseQueryAndPagination = function (
-  config
-) {
+export const useQueryAndPagination: IUseQueryAndPagination = function (config) {
   const { indexType = IndexType.ZERO_BASED, pageSize = 15 } = config || {}
   const router = useRouter()
 

--- a/src/nextRouterPagination.tsx
+++ b/src/nextRouterPagination.tsx
@@ -19,7 +19,7 @@ function extractCurrentQueryParameters(
     return {}
   }
 
-  const result: QueryParameters = defaultQueryParameters
+  const result: QueryParameters = { ...defaultQueryParameters }
 
   for (const parameter in defaultQueryParameters) {
     if (

--- a/src/reactRouterPagination.tsx
+++ b/src/reactRouterPagination.tsx
@@ -31,7 +31,7 @@ export const useQueryAndPagination: IUseQueryAndPagination = function (config) {
 
   const params = useMemo(() => new URLSearchParams(routeQuery), [routeQuery])
 
-  const query = useCallback(
+  const updateQuery = useCallback(
     (queryParameters: QueryParameters) => {
       for (const parameter in queryParameters) {
         if (
@@ -92,7 +92,7 @@ export const useQueryAndPagination: IUseQueryAndPagination = function (config) {
     ),
     size: convert(params.get('size'), pageSize),
     actions: {
-      query,
+      updateQuery,
       clear,
       setPage,
     },

--- a/src/reactRouterPagination.tsx
+++ b/src/reactRouterPagination.tsx
@@ -12,7 +12,7 @@ function extractCurrentQueryParameters(
     return {}
   }
 
-  const result: QueryParameters = defaultQueryParameters
+  const result: QueryParameters = { ...defaultQueryParameters }
 
   for (const parameter in defaultQueryParameters) {
     if (query.get(parameter)) {

--- a/src/reactRouterPagination.tsx
+++ b/src/reactRouterPagination.tsx
@@ -1,10 +1,10 @@
 import { useCallback, useMemo } from 'react'
 import { useHistory, useLocation, useRouteMatch } from 'react-router-dom'
 
-import { IndexType, IUseSearchAndPagination } from './types'
+import { IndexType, IUseQueryAndPagination } from './types'
 import { convert } from './utils'
 
-export const useSearchAndPagination: IUseSearchAndPagination = function (
+export const useSearchAndPagination: IUseQueryAndPagination = function (
   config
 ) {
   const { indexType = IndexType.ZERO_BASED, pageSize = 15 } = config || {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export type Config = {
 }
 
 export type Actions = {
-  query: (query: QueryParameters) => void
+  updateQuery: (query: QueryParameters) => void
   clear: () => void
   setPage: (page: number) => void
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,24 +3,27 @@ export enum IndexType {
   ONE_BASED = 1,
 }
 
+export type QueryParameters = Record<string, string>
+
 export type Config = {
   indexType?: IndexType
   pageSize?: number
+  defaultQueryParameters?: QueryParameters
 }
 
 export type Actions = {
-  search: (query: string) => void
+  query: (query: QueryParameters) => void
   clear: () => void
   setPage: (page: number) => void
 }
 
-export type UseSearchAndPagination = {
-  search: string
+export type UseQueryAndPagination = {
+  queryParameters: QueryParameters
   page: number
   size: number
   actions: Actions
 }
 
-export interface IUseSearchAndPagination {
-  (config?: Config): UseSearchAndPagination
+export interface IUseQueryAndPagination {
+  (config?: Config): UseQueryAndPagination
 }

--- a/tsconfig.esnext.json
+++ b/tsconfig.esnext.json
@@ -9,6 +9,7 @@
     "outDir": "./dist/esm",
     "declaration": true,
     "strict": true,
+    "skipLibCheck": true
   },
   "include": ["src"],
   "exclude": ["node_modules", "**/__test__/*", "**/__tests__/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
       "outDir": "./dist",
       "declaration": true,
       "strict": true,
-      "sourceMap": true
+      "sourceMap": true,
+      "skipLibCheck": true
     },
     "include": ["src"],
     "exclude": ["node_modules", "**/__test__/*", "**/__tests__/*"]


### PR DESCRIPTION
In order to be more flexible, we need to be able to query mutliple fields and not just search.

Therefore I replaced search with query and let the user pass an object with multiple fields.


Example:

```
const {actions, queryParameters } = useQueryAndPagination({ defaultQueryParameters: { search: '' } })


const search = (value) => {actions.query({search: value})}
const filterDepartment = (value) => {actions.query({department: value})}

```

