### PR TITLE
Handle falsy query parameter values correctly

### DIFF
--- a/src/__test__/inMemoryPagination.test.ts
+++ b/src/__test__/inMemoryPagination.test.ts
@@ -113,3 +113,17 @@ test('query a property that is not configured, should do nothing', () => {
   expect(result.current.queryParameters.search).toBe('')
   expect(result.current.queryParameters.department).toBeUndefined()
 })
+
+test('query property with empty value and different default value', () => {
+  const { result } = renderHook(() =>
+    useQueryAndPagination({
+      defaultQueryParameters: { search: 'Default search' },
+    })
+  )
+
+  act(() => {
+    result.current.actions.updateQuery({ search: '' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('')
+})

--- a/src/__test__/nextRouterPagination.test.tsx
+++ b/src/__test__/nextRouterPagination.test.tsx
@@ -168,3 +168,18 @@ test('query property with default value, should remove it from url', () => {
   expect(result.current.queryParameters.search).toBe('')
   expect(router.query.search).toBeUndefined()
 })
+
+test('query property with empty value and different default value', () => {
+  const { result } = renderHook(() =>
+    useQueryAndPagination({
+      defaultQueryParameters: { search: 'Default search' },
+    })
+  )
+
+  act(() => {
+    result.current.actions.updateQuery({ search: '' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('')
+  expect(router.query.search).toBe('')
+})

--- a/src/__test__/reactRouterPagination.test.tsx
+++ b/src/__test__/reactRouterPagination.test.tsx
@@ -151,3 +151,20 @@ test('query property with default value, should remove it from url', () => {
   expect(result.current.queryParameters.search).toBe('')
   expect(window.location.search).toBe('')
 })
+
+test('query property with empty value and different default value', () => {
+  const { result } = renderHook(
+    () =>
+      useQueryAndPagination({
+        defaultQueryParameters: { search: 'Default search' },
+      }),
+    { wrapper }
+  )
+
+  act(() => {
+    result.current.actions.updateQuery({ search: '' })
+  })
+
+  expect(result.current.queryParameters.search).toBe('')
+  expect(window.location.search).toBe('?search=')
+})

--- a/src/nextRouterPagination.tsx
+++ b/src/nextRouterPagination.tsx
@@ -22,11 +22,10 @@ function extractCurrentQueryParameters(
   const result: QueryParameters = { ...defaultQueryParameters }
 
   for (const parameter in defaultQueryParameters) {
-    if (
-      query[parameter] &&
-      getSingleParameterValue(query[parameter]) !== undefined
-    ) {
-      result[parameter] = getSingleParameterValue(query[parameter]) as string
+    const queryParameter = getSingleParameterValue(query[parameter])
+
+    if (typeof queryParameter !== 'undefined') {
+      result[parameter] = queryParameter
     }
   }
 

--- a/src/reactRouterPagination.tsx
+++ b/src/reactRouterPagination.tsx
@@ -15,8 +15,10 @@ function extractCurrentQueryParameters(
   const result: QueryParameters = { ...defaultQueryParameters }
 
   for (const parameter in defaultQueryParameters) {
-    if (query.get(parameter)) {
-      result[parameter] = query.get(parameter) as string
+    const queryParameter = query.get(parameter)
+
+    if (queryParameter !== null) {
+      result[parameter] = queryParameter
     }
   }
 


### PR DESCRIPTION
The library should return the actual query parameter value instead of the default value, even if it is a falsy value (e.g. `''` or `'0'`).