### PR TITLE
Fix Next router and make default query optional

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -58,7 +58,7 @@ const parseSearch = (query: Query) => {
 
 export function UserList() {
   const { page, size, query, setQuery, setPage, resetQuery } =
-    useQueryAndPagination({ search: '' }, parseSearch)
+    useQueryAndPagination(parseSearch, { search: '' })
 
   return (
     <div>
@@ -116,10 +116,14 @@ const users = [
 
 export function UserList() {
   const { page, size, query, setQuery, setPage, resetQuery } =
-    useQueryAndPagination({ name: '', age: 0 }, userSchema, {
-      page: 0,
-      size: 4,
-    })
+    useQueryAndPagination:
+      userSchema,
+      { name: '', age: 0 },
+      {
+        page: 0,
+        size: 4,
+      },
+    )
 
   return (
     <div>

--- a/src/engine/pagination.ts
+++ b/src/engine/pagination.ts
@@ -46,11 +46,14 @@ const parsePagination = (query: Query): Partial<PaginationQuery> => {
   }
 }
 
-export const useAbstractQueryAndPagination = <T extends AbstractQuery>(
-  defaultQuery: T,
-  parseQuery: ParseQuery<T>,
+export const useAbstractQueryAndPagination = <
+  TQuery extends AbstractQuery,
+  TDefaultQuery extends Partial<TQuery>,
+>(
   router: Router,
-  defaultPagination?: PaginationQuery,
+  parseQuery: ParseQuery<TQuery>,
+  defaultQuery: TDefaultQuery,
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions>,
 ) => {
   const mergedDefaultPagination = {
@@ -63,9 +66,9 @@ export const useAbstractQueryAndPagination = <T extends AbstractQuery>(
   }
 
   const { query, setQuery } = useAbstractQuery(
-    mergedDefaultQueryAndPagination,
-    parseQuery,
     router,
+    parseQuery,
+    mergedDefaultQueryAndPagination,
     options,
   )
 
@@ -74,15 +77,18 @@ export const useAbstractQueryAndPagination = <T extends AbstractQuery>(
     setQuery: setPagination,
     resetQuery: resetPagination,
   } = useAbstractQuery(
-    mergedDefaultPagination,
-    parsePagination,
     router,
+    parsePagination,
+    mergedDefaultPagination,
     options,
   )
 
   return {
     query,
-    setQuery: (query: Partial<T>, options?: Partial<ChangeQueryOptions>) => {
+    setQuery: (
+      query: Partial<TQuery>,
+      options?: Partial<ChangeQueryOptions>,
+    ) => {
       const mergedOptions = { ...DEFAULT_CHANGE_QUERY_OPTIONS, ...options }
       setQuery({
         ...query,

--- a/src/routers/__test__/inMemory.test.ts
+++ b/src/routers/__test__/inMemory.test.ts
@@ -1,6 +1,5 @@
 import { act, renderHook } from '@testing-library/react'
 import { z } from 'zod'
-import { NonNullableRecord } from '../../utils'
 import { useQuery, useQueryAndPagination } from '../../zod/routers/inMemory'
 import { usePagination } from '../inMemory'
 
@@ -10,8 +9,8 @@ describe('InMemory', () => {
   })
 
   const useInMemoryQueryWithSearch = (
-    defaultQuery: NonNullableRecord<z.infer<typeof searchSchema>>,
-  ) => useQuery(defaultQuery, searchSchema)
+    defaultQuery: Partial<z.output<typeof searchSchema>> = {},
+  ) => useQuery(searchSchema, defaultQuery)
 
   test('should set default page and size', () => {
     const page = 0
@@ -53,7 +52,7 @@ describe('InMemory', () => {
     const page = 2
 
     const { result } = renderHook(() =>
-      useQueryAndPagination({ search: '' }, searchSchema),
+      useQueryAndPagination(searchSchema, { search: '' }),
     )
 
     act(() => {
@@ -90,7 +89,7 @@ describe('InMemory', () => {
     const page = 2
 
     const { result } = renderHook(() =>
-      useQueryAndPagination({ search: defaultSearch }, searchSchema),
+      useQueryAndPagination(searchSchema, { search: defaultSearch }),
     )
 
     act(() => {
@@ -125,7 +124,7 @@ describe('InMemory', () => {
     const page = 2
 
     const { result } = renderHook(() =>
-      useQueryAndPagination({ search: defaultSearch }, searchSchema),
+      useQueryAndPagination(searchSchema, { search: defaultSearch }),
     )
 
     act(() => {
@@ -159,7 +158,7 @@ describe('InMemory', () => {
     })
 
     const { result } = renderHook(() =>
-      useQuery({ search: '', department: '' }, schema),
+      useQuery(schema, { search: '', department: '' }),
     )
 
     act(() => {
@@ -178,7 +177,7 @@ describe('InMemory', () => {
     const search = ''
 
     const { result } = renderHook(() =>
-      useQuery({ search: 'Default search' }, searchSchema),
+      useQuery(searchSchema, { search: 'Default search' }),
     )
 
     act(() => {

--- a/src/routers/__test__/reactRouter.test.tsx
+++ b/src/routers/__test__/reactRouter.test.tsx
@@ -1,7 +1,6 @@
 import { act, renderHook } from '@testing-library/react'
 import { z } from 'zod'
 import { BrowserRouter } from 'react-router-dom'
-import { NonNullableRecord } from '../../utils'
 import { useQuery, useQueryAndPagination } from '../../zod/routers/reactRouter'
 import { usePagination } from '../reactRouter'
 
@@ -24,8 +23,8 @@ describe('ReactRouter', () => {
   })
 
   const useReactRouterQueryWithSearch = (
-    defaultQuery: NonNullableRecord<z.infer<typeof searchSchema>>,
-  ) => useQuery(defaultQuery, searchSchema)
+    defaultQuery: Partial<z.infer<typeof searchSchema>> = {},
+  ) => useQuery(searchSchema, defaultQuery)
 
   test('should set default page and size', () => {
     const page = 0
@@ -71,7 +70,7 @@ describe('ReactRouter', () => {
     const page = 2
 
     const { result } = renderHookWithContext(() =>
-      useQueryAndPagination({ search: '' }, searchSchema),
+      useQueryAndPagination(searchSchema, { search: '' }),
     )
 
     act(() => {
@@ -111,7 +110,7 @@ describe('ReactRouter', () => {
     const page = 2
 
     const { result } = renderHookWithContext(() =>
-      useQueryAndPagination({ search: defaultSearch }, searchSchema),
+      useQueryAndPagination(searchSchema, { search: defaultSearch }),
     )
 
     act(() => {
@@ -149,7 +148,7 @@ describe('ReactRouter', () => {
     const page = 2
 
     const { result } = renderHookWithContext(() =>
-      useQueryAndPagination({ search: defaultSearch }, searchSchema),
+      useQueryAndPagination(searchSchema, { search: defaultSearch }),
     )
 
     act(() => {
@@ -186,7 +185,7 @@ describe('ReactRouter', () => {
     })
 
     const { result } = renderHookWithContext(() =>
-      useQuery({ search: '', department: '' }, schema),
+      useQuery(schema, { search: '', department: '' }),
     )
 
     act(() => {
@@ -207,7 +206,7 @@ describe('ReactRouter', () => {
     window.history.pushState({}, '', `/?greeting=${greeting}`)
 
     const { result } = renderHookWithContext(() =>
-      useQuery({ search: '' }, searchSchema),
+      useQuery(searchSchema, { search: '' }),
     )
 
     act(() => {
@@ -226,7 +225,7 @@ describe('ReactRouter', () => {
     window.history.pushState({}, '', `/?search=Max`)
 
     const { result } = renderHookWithContext(() =>
-      useQuery({ search: defaultSearch }, searchSchema),
+      useQuery(searchSchema, { search: defaultSearch }),
     )
 
     act(() => {
@@ -241,7 +240,7 @@ describe('ReactRouter', () => {
     const search = ''
 
     const { result } = renderHookWithContext(() =>
-      useQuery({ search: 'Default search' }, searchSchema),
+      useQuery(searchSchema, { search: 'Default search' }),
     )
 
     act(() => {

--- a/src/routers/inMemory.ts
+++ b/src/routers/inMemory.ts
@@ -29,36 +29,36 @@ const useInMemoryRouter = (): Router => {
   }
 }
 
-export const useQuery = <T extends AbstractQuery>(
-  defaultQuery: T,
-  parseQuery: ParseQuery<T>,
+export const useQuery = <TQuery extends AbstractQuery>(
+  parseQuery: ParseQuery<TQuery>,
+  defaultQuery: Partial<TQuery> = {},
   options?: Partial<AbstractQueryOptions>,
 ) => {
   const router = useInMemoryRouter()
-  return useAbstractQuery(defaultQuery, parseQuery, router, options)
+  return useAbstractQuery(router, parseQuery, defaultQuery, options)
 }
 
-export const useQueryAndPagination = <T extends AbstractQuery>(
-  defaultQuery: T,
-  parseQuery: ParseQuery<T>,
-  defaultPagination?: PaginationQuery,
+export const useQueryAndPagination = <TQuery extends AbstractQuery>(
+  parseQuery: ParseQuery<TQuery>,
+  defaultQuery: Partial<TQuery> = {},
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions>,
 ) => {
   const router = useInMemoryRouter()
   return useAbstractQueryAndPagination(
-    defaultQuery,
-    parseQuery,
     router,
+    parseQuery,
+    defaultQuery,
     defaultPagination,
     options,
   )
 }
 
 export const usePagination = (
-  defaultPagination?: PaginationQuery,
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions>,
 ) => {
   const { page, size, setPage, setSize, setPagination, resetPagination } =
-    useQueryAndPagination({}, () => ({}), defaultPagination, options)
+    useQueryAndPagination(() => ({}), {}, defaultPagination, options)
   return { page, size, setPage, setSize, setPagination, resetPagination }
 }

--- a/src/routers/nextRouter.ts
+++ b/src/routers/nextRouter.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   Query,
   ParseQuery,
@@ -22,16 +22,25 @@ const useNextRouter = (
   options: undefined | Partial<RouterWithHistoryOptions>,
 ): Router => {
   const nextRouter = useRouter()
+  const [nextRouterQuery, setNextRouterQuery] = useState<
+    typeof nextRouter.query
+  >({})
 
   const mergedOptions = useMemo(
     () => ({ ...DEFAULT_NEXT_ROUTER_OPTIONS, ...options }),
     [options],
   )
 
+  useEffect(() => {
+    if (nextRouter.isReady) {
+      setNextRouterQuery(nextRouter.query)
+    }
+  }, [nextRouter.isReady, nextRouter.query])
+
   return {
     getQuery: (defaultQuery) => {
       const query: Query = {}
-      for (const [key, value] of Object.entries(nextRouter.query)) {
+      for (const [key, value] of Object.entries(nextRouterQuery)) {
         if (value !== undefined) {
           query[key] = value
         }
@@ -39,7 +48,7 @@ const useNextRouter = (
       return { ...defaultQuery, ...query }
     },
     setQuery: (query, defaultQuery) => {
-      const newQuery = { ...nextRouter.query, ...query }
+      const newQuery = { ...nextRouterQuery, ...query }
       const newQueryWithoutDefaults = Object.fromEntries(
         Object.entries(newQuery).filter(
           ([key, value]) => value !== defaultQuery[key],

--- a/src/routers/nextRouter.ts
+++ b/src/routers/nextRouter.ts
@@ -67,36 +67,36 @@ const useNextRouter = (
   }
 }
 
-export const useQuery = <T extends AbstractQuery>(
-  defaultQuery: T,
-  parseQuery: ParseQuery<T>,
+export const useQuery = <TQuery extends AbstractQuery>(
+  parseQuery: ParseQuery<TQuery>,
+  defaultQuery: Partial<TQuery> = {},
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
 ) => {
   const router = useNextRouter(options)
-  return useAbstractQuery(defaultQuery, parseQuery, router, options)
+  return useAbstractQuery(router, parseQuery, defaultQuery, options)
 }
 
-export const useQueryAndPagination = <T extends AbstractQuery>(
-  defaultQuery: T,
-  parseQuery: ParseQuery<T>,
-  defaultPagination?: PaginationQuery,
+export const useQueryAndPagination = <TQuery extends AbstractQuery>(
+  parseQuery: ParseQuery<TQuery>,
+  defaultQuery: Partial<TQuery> = {},
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
 ) => {
   const router = useNextRouter(options)
   return useAbstractQueryAndPagination(
-    defaultQuery,
-    parseQuery,
     router,
+    parseQuery,
+    defaultQuery,
     defaultPagination,
     options,
   )
 }
 
 export const usePagination = (
-  defaultPagination?: PaginationQuery,
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
 ) => {
   const { page, size, setPage, setSize, setPagination, resetPagination } =
-    useQueryAndPagination({}, () => ({}), defaultPagination, options)
+    useQueryAndPagination(() => ({}), {}, defaultPagination, options)
   return { page, size, setPage, setSize, setPagination, resetPagination }
 }

--- a/src/routers/reactRouter.ts
+++ b/src/routers/reactRouter.ts
@@ -67,36 +67,36 @@ const useReactRouter = (
   }
 }
 
-export const useQuery = <T extends AbstractQuery>(
-  defaultQuery: T,
-  parseQuery: ParseQuery<T>,
+export const useQuery = <TQuery extends AbstractQuery>(
+  parseQuery: ParseQuery<TQuery>,
+  defaultQuery: Partial<TQuery> = {},
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
 ) => {
   const router = useReactRouter(options)
-  return useAbstractQuery(defaultQuery, parseQuery, router, options)
+  return useAbstractQuery(router, parseQuery, defaultQuery, options)
 }
 
-export const useQueryAndPagination = <T extends AbstractQuery>(
-  defaultQuery: T,
-  parseQuery: ParseQuery<T>,
-  defaultPagination?: PaginationQuery,
+export const useQueryAndPagination = <TQuery extends AbstractQuery>(
+  parseQuery: ParseQuery<TQuery>,
+  defaultQuery: Partial<TQuery> = {},
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
 ) => {
   const router = useReactRouter(options)
   return useAbstractQueryAndPagination(
-    defaultQuery,
-    parseQuery,
     router,
+    parseQuery,
+    defaultQuery,
     defaultPagination,
     options,
   )
 }
 
 export const usePagination = (
-  defaultPagination?: PaginationQuery,
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
 ) => {
   const { page, size, setPage, setSize, setPagination, resetPagination } =
-    useQueryAndPagination({}, () => ({}), defaultPagination, options)
+    useQueryAndPagination(() => ({}), {}, defaultPagination, options)
   return { page, size, setPage, setSize, setPagination, resetPagination }
 }

--- a/src/zod/routers/inMemory.ts
+++ b/src/zod/routers/inMemory.ts
@@ -4,24 +4,29 @@ import {
   useQuery as useQueryVanilla,
   useQueryAndPagination as useQueryAndPaginationVanilla,
 } from '../../routers/inMemory'
-import { NonNullableRecord } from '../../utils'
 import { zodParser } from '../util'
 
-export const useQuery = <TSchema extends z.ZodTypeAny>(
-  defaultQuery: NonNullableRecord<z.output<TSchema>>,
+export const useQuery = <
+  TSchema extends z.ZodTypeAny,
+  TQuery extends z.output<TSchema>,
+>(
   schemaQuery: TSchema,
+  defaultQuery: Partial<TQuery> = {},
   options?: Partial<AbstractQueryOptions>,
-) => useQueryVanilla(defaultQuery, zodParser(schemaQuery), options)
+) => useQueryVanilla(zodParser(schemaQuery), defaultQuery, options)
 
-export const useQueryAndPagination = <TSchema extends z.ZodTypeAny>(
-  defaultQuery: NonNullableRecord<z.output<TSchema>>,
+export const useQueryAndPagination = <
+  TSchema extends z.ZodTypeAny,
+  TQuery extends z.output<TSchema>,
+>(
   schemaQuery: TSchema,
-  defaultPagination?: PaginationQuery,
+  defaultQuery: Partial<TQuery> = {},
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions>,
 ) =>
   useQueryAndPaginationVanilla(
-    defaultQuery,
     zodParser(schemaQuery),
+    defaultQuery,
     defaultPagination,
     options,
   )

--- a/src/zod/routers/nextRouter.ts
+++ b/src/zod/routers/nextRouter.ts
@@ -6,23 +6,28 @@ import {
 } from '../../routers/nextRouter'
 import { zodParser } from '../util'
 import { RouterWithHistoryOptions } from '../../routers/shared'
-import { NonNullableRecord } from '../../utils'
 
-export const useQuery = <TSchema extends z.ZodTypeAny>(
-  defaultQuery: NonNullableRecord<z.output<TSchema>>,
+export const useQuery = <
+  TSchema extends z.ZodTypeAny,
+  TQuery extends z.output<TSchema>,
+>(
   schemaQuery: TSchema,
+  defaultQuery: Partial<TQuery> = {},
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
-) => useQueryVanilla(defaultQuery, zodParser(schemaQuery), options)
+) => useQueryVanilla(zodParser(schemaQuery), defaultQuery, options)
 
-export const useQueryAndPagination = <TSchema extends z.ZodTypeAny>(
-  defaultQuery: NonNullableRecord<z.output<TSchema>>,
+export const useQueryAndPagination = <
+  TSchema extends z.ZodTypeAny,
+  TQuery extends z.output<TSchema>,
+>(
   schemaQuery: TSchema,
-  defaultPagination?: PaginationQuery,
+  defaultQuery: Partial<TQuery> = {},
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
 ) =>
   useQueryAndPaginationVanilla(
-    defaultQuery,
     zodParser(schemaQuery),
+    defaultQuery,
     defaultPagination,
     options,
   )

--- a/src/zod/routers/reactRouter.ts
+++ b/src/zod/routers/reactRouter.ts
@@ -6,23 +6,28 @@ import {
 } from '../../routers/reactRouter'
 import { zodParser } from '../util'
 import { RouterWithHistoryOptions } from '../../routers/shared'
-import { NonNullableRecord } from '../../utils'
 
-export const useQuery = <TSchema extends z.ZodTypeAny>(
-  defaultQuery: NonNullableRecord<z.output<TSchema>>,
+export const useQuery = <
+  TSchema extends z.ZodTypeAny,
+  TQuery extends z.output<TSchema>,
+>(
   schemaQuery: TSchema,
+  defaultQuery: Partial<TQuery> = {},
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
-) => useQueryVanilla(defaultQuery, zodParser(schemaQuery), options)
+) => useQueryVanilla(zodParser(schemaQuery), defaultQuery, options)
 
-export const useQueryAndPagination = <TSchema extends z.ZodTypeAny>(
-  defaultQuery: NonNullableRecord<z.output<TSchema>>,
+export const useQueryAndPagination = <
+  TSchema extends z.ZodTypeAny,
+  TQuery extends z.output<TSchema>,
+>(
   schemaQuery: TSchema,
-  defaultPagination?: PaginationQuery,
+  defaultQuery: Partial<TQuery> = {},
+  defaultPagination?: Partial<PaginationQuery>,
   options?: Partial<AbstractQueryOptions & RouterWithHistoryOptions>,
 ) =>
   useQueryAndPaginationVanilla(
-    defaultQuery,
     zodParser(schemaQuery),
+    defaultQuery,
     defaultPagination,
     options,
   )


### PR DESCRIPTION
Optional default queries allow us to use the hook `useQuery` for parsing the query without having a default value. It allows us to receive the value from the query if it exists and is correct or undefined if otherwise. A typical use case is when a page is not rendered if a necessary query value is missing.

To support optional default queries, it was necessary to change the arguments order. Because this is a breaking change, the next version should be version 3.