### PR TITLE
Null as query value

### DIFF
--- a/src/engine/query.ts
+++ b/src/engine/query.ts
@@ -8,6 +8,7 @@ export type AbstractQueryValueElement =
   | boolean
   | Date
   | bigint
+  | null
 
 export type AbstractQuery = Record<
   string,
@@ -54,7 +55,7 @@ export type AbstractQueryOptions = {
   /**
    * How the abstract query is converted to an actual query.
    *
-   * @default Each value that is not undefined is converted to a string by calling `.toString()`.
+   * @default Each value that is not undefined and is converted to a string. `null` is converted to an empty string, while other values are converted calling `String(value)`.
    */
   convertToQuery: (abstractQuery: Partial<AbstractQuery>) => Query
 }
@@ -64,7 +65,7 @@ const DEFAULT_ABSTRACT_QUERY_OPTIONS: AbstractQueryOptions = {
     const query: Query = {}
     for (const [key, value] of Object.entries(abstractQuery)) {
       if (value !== undefined) {
-        query[key] = value.toString()
+        query[key] = value === null ? '' : String(value)
       }
     }
     return query

--- a/src/routers/__test__/nextRouter.test.ts
+++ b/src/routers/__test__/nextRouter.test.ts
@@ -5,8 +5,7 @@ import { expectTypeOf, vi } from 'vitest'
 import { useQuery, useQueryAndPagination } from '../../zod/routers/nextRouter'
 import { usePagination } from '../nextRouter'
 
-// eslint-disable-next-line @typescript-eslint/no-unsafe-return
-vi.mock('next/router', () => require('next-router-mock'))
+vi.mock('next/router', async () => await import('next-router-mock'))
 
 describe('NextRouter', () => {
   beforeEach(() => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "@aboutbits/ts-config/react",
   "compilerOptions": {
+    "module": "es2020",
     "moduleResolution": "node",
     "skipLibCheck": true
   },


### PR DESCRIPTION
Adds support for `null` as a query value. `null` is converted to an empty string when writing the query.